### PR TITLE
Fix multilines support in Xain.Helpers.id_and_class_shortcuts.

### DIFF
--- a/lib/xain/helpers.ex
+++ b/lib/xain/helpers.ex
@@ -80,7 +80,7 @@ defmodule Xain.Helpers do
   @tag_class_id ~S/(^%|[.#])[-:\w]+/
   @rest         ~S/(.+)/
 
-  @regex        ~r/(?:#{@tag_class_id}|#{@rest})\s*/
+  @regex        ~r/(?:#{@tag_class_id}|#{@rest})\s*/s
 
 
   defp tokenize(string) do

--- a/test/xain/helpers_test.exs
+++ b/test/xain/helpers_test.exs
@@ -20,4 +20,13 @@ defmodule Xain.HelpersTest do
   test "id_and_class_shortcuts #id" do
     assert id_and_class_shortcuts("#test", []) == {"", [id: "test"]}
   end
+
+  test "id_and_class_shortcuts doesn't broke multilines" do
+    str = """
+      line1
+      line2
+      line3
+    """
+    assert id_and_class_shortcuts(str, []) == {str, []}
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/smpallen99/ex_admin/issues/133
