### PR TITLE
Attempt to escape html entities in attributes/content

### DIFF
--- a/lib/xain.ex
+++ b/lib/xain.ex
@@ -123,7 +123,7 @@ defmodule Xain do
   defp merge_attrs(content, attrs, tag_name) do
     attrs = attrs |> set_defaults(tag_name)
     {content, attrs} = id_and_class_shortcuts(content, attrs)
-    attrs_html = for {key, val} <- attrs, into: "", do: " #{key}=#{quote_symbol}#{val}#{quote_symbol}"
+    attrs_html = for {key, val} <- attrs, into: "", do: " #{key}=#{quote_symbol}#{html_escape(val)}#{quote_symbol}"
     {content, attrs_html}
   end
 
@@ -180,7 +180,7 @@ defmodule Xain do
   end
 
   defmacro text(string) do
-    quote do: to_string(unquote(string))
+    quote do: to_string(unquote(html_escape(string)))
   end
 
   defmacro raw(string) do
@@ -199,5 +199,23 @@ defmodule Xain do
 
   defp set_defaults(attrs, name) do
     Keyword.merge(get_defaults(name), attrs)
+  end
+
+  defp html_escape(html) do
+    if is_binary(html) do
+      for <<char <- html>>, do: html_entity(char)
+    else
+      html
+    end
+  end
+
+  defp html_entity(char) do
+    case char do
+      ?< -> "&lt;"
+      ?> -> "&gt;"
+      ?" -> "&quot;"
+      ?' -> "&apos;"
+      _ -> <<char>>
+    end
   end
 end

--- a/test/xain_test.exs
+++ b/test/xain_test.exs
@@ -298,4 +298,16 @@ defmodule XainTest do
     end
     assert result == ~s(<div></div>)
   end
+
+  test "escapes html entities in attributes" do
+    result = div title: "\"hello\""
+    assert result == ~s(<div title="&quot;hello&quot;"></div>)
+  end
+  test "escapes html entities in text" do
+    result = div do
+      text "<hello>"
+      b "world"
+    end
+    assert result == ~s(<div>&lt;hello&gt;<b>world</b></div>)
+  end
 end


### PR DESCRIPTION
The private `html_escape` is introduced in an attempt to properly escape html text. The values passed to attributes and the `text` macro will be escaped. However i am unsure how to apply escaping to all textual inner content without escaping inner tags.
